### PR TITLE
Updated download location for latest MBAM hotfix

### DIFF
--- a/mdop/mbam-v25/apply-hotfix-for-mbam-25-sp1.md
+++ b/mdop/mbam-v25/apply-hotfix-for-mbam-25-sp1.md
@@ -17,7 +17,7 @@ ms.date: 8/30/2018
 This topic describes the process for applying the hotfixes for Microsoft BitLocker Administration and Monitoring (MBAM) Server 2.5 SP1
 
 ### Before you begin, download the latest hotfix of Microsoft BitLocker Administration and Monitoring (MBAM) Server 2.5 SP1
-[Desktop Optimization Pack](https://www.microsoft.com/download/details.aspx?id=57157)
+[Desktop Optimization Pack](https://www.microsoft.com/download/details.aspx?id=102262)
 
 > [!NOTE]
 > For more information about the hotfix releases, see the [MBAM version chart](https://docs.microsoft.com/archive/blogs/dubaisec/mbam-version-chart).


### PR DESCRIPTION
The link to the latest Desktop Optimization Pack was still pointing at the July 2018 release, when there has since been one in May 2019 (58345), and now October 2020 (which the link has been updated to).