### PR TITLE
Update mbam-25-supported-configurations.md

### DIFF
--- a/mdop/mbam-v25/mbam-25-supported-configurations.md
+++ b/mdop/mbam-v25/mbam-25-supported-configurations.md
@@ -162,6 +162,12 @@ The following table lists the operating systems that are supported for the MBAM 
 </thead>
 <tbody>
 <tr class="odd">
+<td align="left"><p>Windows Server 2019</p></td>
+<td align="left"><p>Standard or Datacenter</p></td>
+<td align="left"></td>
+<td align="left"><p>64-bit</p></td>
+</tr>
+<tr class="odd">
 <td align="left"><p>Windows Server 2016</p></td>
 <td align="left"><p>Standard or Datacenter</p></td>
 <td align="left"></td>
@@ -345,6 +351,10 @@ You must install SQL Server with the **SQL\_Latin1\_General\_CP1\_CI\_AS** colla
 </thead>
 <tbody>
 <tr class="odd">
+<td align="left"><p>Microsoft SQL Server 2019</p></td>
+<td align="left"><p>Standard, Enterprise, or Datacenter</p></td>
+<td align="left"><p></p></td>
+<td align="left"><p>64-bit</p></td><br/><tr class="even">
 <td align="left"><p>Microsoft SQL Server 2017</p></td>
 <td align="left"><p>Standard, Enterprise, or Datacenter</p></td>
 <td align="left"><p></p></td>
@@ -373,6 +383,8 @@ You must install SQL Server with the **SQL\_Latin1\_General\_CP1\_CI\_AS** colla
 </table>
 
 **Note**  
+MBAM has a maximum supported compatibility level of 140. The default compatibility level for new databases created on SQL Server 2019 is 150 which will need to be altered to 140 or lower, using the ALTER DATABASE command, after the database has been created. Existing databases migrated from SQL server 2017 or below will remain at their previous compatibility level and do not need to be altered.
+
 In order to support SQL 2016 you must install the March 2017 Servicing Release for MDOP https://www.microsoft.com/download/details.aspx?id=54967  and to support SQL 2017 you must install the July 2018 Servicing Release for MDOP https://www.microsoft.com/download/details.aspx?id=57157. In general stay current by always using the most recent servicing update as it also includes all bugfixes and new features.
 
 


### PR DESCRIPTION
Changes per Poornima Priyadarshini

MBAM Server Operating system requirements: 
Instruction for editing: Add a row for Windows Server 2019 support
https://docs.microsoft.com/en-us/microsoft-desktop-optimization-pack/mbam-v25/mbam-25-supported-configurations#sql-server-database-requirements
The following table lists the operating systems that are supported for the MBAM Server installation.

MBAM SERVER OPERATING SYSTEM REQUIREMENTS

Operating system

Edition

Service pack

System architecture

Windows Server 2019

Standard or Datacenter

 

64-bit

Windows Server 2016

Standard or Datacenter

64-bit

Windows Server 2012 R2

Standard or Datacenter

64-bit

Windows Server 2012

Standard or Datacenter

64-bit

Windows Server 2008 R2

Standard, Enterprise, or Datacenter

SP1

64-bit

The enterprise domain must contain at least one Windows Server 2008 (or later) domain controller.



SQL Server database requirements
Instructions for editing: Add content below

The following table lists the Microsoft SQL Server versions that are supported for the MBAM Server features, which include the Recovery Database, Compliance and Audit Database, and the Reports feature. The required versions apply to the Stand-alone or the Configuration Manager Integration topologies.

You must install SQL Server with the SQL_Latin1_General_CP1_CI_AS collation.


https://www.microsoft.com/download/details.aspx?id=54967

SQL SERVER DATABASE REQUIREMENTS

SQL Server version

Edition

Service pack

System architecture

Microsoft SQL Server 2019

Standard, Enterprise, or Datacenter

 

64-bit

Microsoft SQL Server 2017

Standard, Enterprise, or Datacenter

64-bit

Microsoft SQL Server 2016

Standard, Enterprise, or Datacenter

SP1

64-bit

Microsoft SQL Server 2014

Standard, Enterprise, or Datacenter

SP1, SP2

64-bit

Microsoft SQL Server 2012

Standard, Enterprise, or Datacenter

SP3

64-bit

Microsoft SQL Server 2008 R2

Standard or Enterprise

SP3

64-bit

Note

MBAM has a maximum supported compatibility level of 140. The default compatibility level for new databases created on SQL Server 2019 is 150 which will need to be altered to 140 or lower, using the ALTER DATABASE command, after the database has been created. Existing databases migrated from SQL server 2017 or below will remain at their previous compatibility level and do not need to be altered.

In order to support SQL 2016 you must install the March 2017 Servicing Release for MDOP https://www.microsoft.com/download/details.aspx?id=54967 and to support SQL 2017 you must install the July 2018 Servicing Release for MDOP https://www.microsoft.com/download/details.aspx?id=57157. In general stay current by always using the most recent servicing update as it also includes all bugfixes and new features.



When does the text need to be live?  ASAP
What platforms and releases are affected? 
The platforms are already listed in the public article. We are requesting update to just one article: https://docs.microsoft.com/en-us/microsoft-desktop-optimization-pack/mbam-v25/mbam-25-supported-configurations#sql-server-database-requirements
When is the fix anticipated/planned to be in?
There is no fix needed.  The compat levels were validated by our dev team