### PR TITLE
Updated/Fixed Formatting in Help Documentation

### DIFF
--- a/mdop/solutions/how-to-download-and-deploy-mdop-group-policy--admx--templates.md
+++ b/mdop/solutions/how-to-download-and-deploy-mdop-group-policy--admx--templates.md
@@ -52,11 +52,11 @@ You can manage the feature settings of certain Microsoft Desktop Optimization Pa
    <tbody>
    <tr class="odd">
    <td align="left"><p>Group Policy template (.admx)</p></td>
-   <td align="left"><p><code>%systemroot%</code>&lt;strong&gt;policyDefinitions</strong></p></td>
+   <td align="left"><p><code>%systemroot%</code>\<strong>policyDefinitions</strong>\</p></td>
    </tr>
    <tr class="even">
    <td align="left"><p>Group Policy language file (.adml)</p></td>
-   <td align="left"><p><code>%systemroot%</code>&lt;strong&gt;policyDefinitions</strong><code>[MUIculture]</code></p></td>
+   <td align="left"><p><code>%systemroot%</code>\<strong>policyDefinitions</strong>\<code>[MUIculture]</code></p></td>
    </tr>
    </tbody>
    </table>
@@ -77,12 +77,12 @@ You can manage the feature settings of certain Microsoft Desktop Optimization Pa
    <tbody>
    <tr class="odd">
    <td align="left"><p>Group Policy template (.admx)</p></td>
-   <td align="left"><p><code>%systemroot%</code>&lt;strong&gt;sysvol\domain\policies\PolicyDefinitions</strong></p></td>
+   <td align="left"><p><code>%systemroot%</code>\<strong>sysvol\domain\policies\PolicyDefinitions</strong>\</p></td>
    </tr>
    <tr class="even">
    <td align="left"><p>Group Policy language file (.adml)</p></td>
-   <td align="left"><p><code>%systemroot%</code>&lt;strong&gt;sysvol\domain\policies\PolicyDefinitions[MUIculture]</strong><code>[MUIculture]</code></p>
-   <p>For example, the U.S. English ADML language-specific file will be stored in %systemroot%\sysvol\domain\policies\PolicyDefinitions\en-us.</p></td>
+   <td align="left"><p><code>%systemroot%</code>\<strong>sysvol\domain\policies\PolicyDefinitions\</strong><code>[MUIculture]</code></p>
+   <p>For example, the U.S. English ADML language-specific file will be stored in <code>%systemroot%\sysvol\domain\policies\PolicyDefinitions\en-us</code>.</p></td>
    </tr>
    </tbody>
    </table>

--- a/mdop/solutions/how-to-download-and-deploy-mdop-group-policy--admx--templates.md
+++ b/mdop/solutions/how-to-download-and-deploy-mdop-group-policy--admx--templates.md
@@ -38,54 +38,17 @@ You can manage the feature settings of certain Microsoft Desktop Optimization Pa
 
    - **Local files:** To configure Group Policy settings from the local device, copy template files to the following locations:
 
-   <table>
-   <colgroup>
-   <col width="50%" />
-   <col width="50%" />
-   </colgroup>
-   <thead>
-   <tr class="header">
-   <th align="left">File type</th>
-   <th align="left">File location</th>
-   </tr>
-   </thead>
-   <tbody>
-   <tr class="odd">
-   <td align="left"><p>Group Policy template (.admx)</p></td>
-   <td align="left"><p><code>%systemroot%</code>\<strong>policyDefinitions</strong>\</p></td>
-   </tr>
-   <tr class="even">
-   <td align="left"><p>Group Policy language file (.adml)</p></td>
-   <td align="left"><p><code>%systemroot%</code>\<strong>policyDefinitions</strong>\<code>[MUIculture]</code></p></td>
-   </tr>
-   </tbody>
-   </table>
+    | File type                                 | File location                                            |
+    | ----------------------------------------  | -------------------------------------------------------- |
+    | Group Policy template (.admx)             | `%systemroot%\policyDefinitions\`                        |
+    | Group Policy language file (.adml)        | `%systemroot%\policyDefinitions\[MUIculture]`            |
 
    - **Domain central store:** To enable Group Policy settings configuration by a Group Policy administrator from any computer on the domain, copy files to the following locations on the domain controller:
 
-   <table>
-   <colgroup>
-   <col width="50%" />
-   <col width="50%" />
-   </colgroup>
-   <thead>
-   <tr class="header">
-   <th align="left">File type</th>
-   <th align="left">File location</th>
-   </tr>
-   </thead>
-   <tbody>
-   <tr class="odd">
-   <td align="left"><p>Group Policy template (.admx)</p></td>
-   <td align="left"><p><code>%systemroot%</code>\<strong>sysvol\domain\policies\PolicyDefinitions</strong>\</p></td>
-   </tr>
-   <tr class="even">
-   <td align="left"><p>Group Policy language file (.adml)</p></td>
-   <td align="left"><p><code>%systemroot%</code>\<strong>sysvol\domain\policies\PolicyDefinitions\</strong><code>[MUIculture]</code></p>
-   <p>For example, the U.S. English ADML language-specific file will be stored in <code>%systemroot%\sysvol\domain\policies\PolicyDefinitions\en-us</code>.</p></td>
-   </tr>
-   </tbody>
-   </table>
+  | File type | File location |
+  | ----------------------------------------  | ----------------------------------------------------------------------------------------------------- |
+  | Group Policy template (.admx) | `%systemroot%\sysvol\domain\policies\PolicyDefinitions\` |
+  | Group Policy language file (.adml) | `%systemroot%\sysvol\domain\policies\PolicyDefinitions\[MUIculture]` <br> For example, the U.S. English ADML language-specific file will be stored in `%systemroot%\sysvol\domain\policies\PolicyDefinitions\en-us`. |
 
 6. Edit the Group Policy settings using Group Policy Management Console (GPMC) or Advanced Group Policy Management (AGPM) to configure Group Policy settings for the MDOP technology.
 
@@ -93,61 +56,11 @@ You can manage the feature settings of certain Microsoft Desktop Optimization Pa
 
 For more information about supported MDOP Group Policy, see the specific documentation for the technology.
 
-<table>
-<colgroup>
-<col width="33%" />
-<col width="33%" />
-<col width="33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th align="left">MDOP Technology</th>
-<th align="left">Version bundles</th>
-<th align="left">Notes</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td align="left"><p><strong>Application Virtualization (App-V)</strong></p></td>
-<td align="left"><p>App-V 5.0 and App-V 5.0 Service Packs</p></td>
-<td align="left"><p><a href="../appv-v5/how-to-modify-app-v-50-client-configuration-using-the-admx-template-and-group-policy.md" data-raw-source="[How to Modify App-V 5.0 Client Configuration Using the ADMX Template and Group Policy](../appv-v5/how-to-modify-app-v-50-client-configuration-using-the-admx-template-and-group-policy.md)">How to Modify App-V 5.0 Client Configuration Using the ADMX Template and Group Policy</a></p></td>
-</tr>
-<tr class="even">
-<td align="left"><p><strong>User Experience Virtualization (UE-V)</strong></p></td>
-<td align="left"><p>UE-V 2.0 and UE-V 2.1</p></td>
-<td align="left"><p><a href="../uev-v2/configuring-ue-v-2x-with-group-policy-objects-both-uevv2.md" data-raw-source="[Configuring UE-V 2.x with Group Policy Objects](../uev-v2/configuring-ue-v-2x-with-group-policy-objects-both-uevv2.md)">Configuring UE-V 2.x with Group Policy Objects</a></p></td>
-</tr>
-<tr class="odd">
-<td align="left"><p></p></td>
-<td align="left"><p>UE-V 1.0 including 1.0 SP1</p></td>
-<td align="left"><p><a href="../uev-v1/configuring-ue-v-with-group-policy-objects.md" data-raw-source="[Configuring UE-V with Group Policy Objects](../uev-v1/configuring-ue-v-with-group-policy-objects.md)">Configuring UE-V with Group Policy Objects</a></p></td>
-</tr>
-<tr class="even">
-<td align="left"><p><strong>Microsoft BitLocker Administration and Monitoring (MBAM)</strong></p></td>
-<td align="left"><p>MBAM 2.5</p></td>
-<td align="left"><p><a href="../mbam-v25/planning-for-mbam-25-group-policy-requirements.md" data-raw-source="[Planning for MBAM 2.5 Group Policy Requirements](../mbam-v25/planning-for-mbam-25-group-policy-requirements.md)">Planning for MBAM 2.5 Group Policy Requirements</a></p></td>
-</tr>
-<tr class="odd">
-<td align="left"><p></p></td>
-<td align="left"><p>MBAM 2.0 including 2.0 SP1</p></td>
-<td align="left"><p><a href="../mbam-v2/planning-for-mbam-20-group-policy-requirements-mbam-2.md" data-raw-source="[Planning for MBAM 2.0 Group Policy Requirements](../mbam-v2/planning-for-mbam-20-group-policy-requirements-mbam-2.md)">Planning for MBAM 2.0 Group Policy Requirements</a></p>
-<p><a href="../mbam-v2/deploying-mbam-20-group-policy-objects-mbam-2.md" data-raw-source="[Deploying MBAM 2.0 Group Policy Objects](../mbam-v2/deploying-mbam-20-group-policy-objects-mbam-2.md)">Deploying MBAM 2.0 Group Policy Objects</a></p></td>
-</tr>
-<tr class="even">
-<td align="left"><p></p></td>
-<td align="left"><p>MBAM 1.0</p></td>
-<td align="left"><p><a href="../mbam-v1/how-to-edit-mbam-10-gpo-settings.md" data-raw-source="[How to Edit MBAM 1.0 GPO Settings](../mbam-v1/how-to-edit-mbam-10-gpo-settings.md)">How to Edit MBAM 1.0 GPO Settings</a></p></td>
-</tr>
-</tbody>
-</table>
-
- 
-
- 
-
- 
-
-
-
-
-
+| MDOP Technology | Version bundles | Notes |
+| ----------------------------------------    | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Application Virtualization (App-V)** | App-V 5.0 and App-V 5.0 Service Packs | [How to Modify App-V 5.0 Client Configuration Using the ADMX Template and Group Policy](../appv-v5/how-to-modify-app-v-50-client-configuration-using-the-admx-template-and-group-policy.md) |
+| **User Experience Virtualization (UE-V)** | UE-V 2.0 and UE-V 2.1 | [Configuring UE-V 2.x with Group Policy Objects](../uev-v2/configuring-ue-v-2x-with-group-policy-objects-both-uevv2.md) |
+| &nbsp; | UE-V 1.0 including 1.0 SP1 | [Configuring UE-V with Group Policy Objects](../uev-v1/configuring-ue-v-with-group-policy-objects.md) |
+| **Microsoft BitLocker Administration and Monitoring (MBAM)** | MBAM 2.5 | [Planning for MBAM 2.5 Group Policy Requirements](../mbam-v25/planning-for-mbam-25-group-policy-requirements.md) |
+| &nbsp; | MBAM 2.0 including 2.0 SP1 | [Planning for MBAM 2.0 Group Policy Requirements](../mbam-v2/planning-for-mbam-20-group-policy-requirements-mbam-2.md) |
+| &nbsp; | MBAM 1.0 | [How to Edit MBAM 1.0 GPO Settings](../mbam-v1/how-to-edit-mbam-10-gpo-settings.md) |


### PR DESCRIPTION
There were several instances where the '<' and '>' were being translated into HTML characters rather than being interpreted as literals in the HTML code. Additionally, there were missing '\' characters in the paths for Local and Domain policy stores.