### PR TITLE
Add info about MDOP download for VS Subscriptions

### DIFF
--- a/mdop/index.md
+++ b/mdop/index.md
@@ -80,6 +80,8 @@ MDOP is a suite of products that can help streamline desktop deployment, managem
 
 MDOP subscribers can download the software at the [Microsoft Volume Licensing website (MVLS)](https://go.microsoft.com/fwlink/p/?LinkId=166331).
 
+Certain Visual Studio [subscription levels](https://learn.microsoft.com/en-us/visualstudio/subscriptions/software-download-list#see-a-list-of-available-software-titles-by-subscription-type) can download MDOP from the Visual Studio [subscription portal Downloads section](https://my.visualstudio.com/downloads).
+
 You can manage the feature settings of certain Microsoft Desktop Optimization Pack (MDOP) technologies (for example, App-V, UE-V, or MBAM) by using group policy templates, the `.admx` and `.adml` files. MDOP group policy templates are available for download in a self-extracting, compressed file, grouped by technology and version. For more information, see [How to download and deploy MDOP group policy (.admx) templates](solutions/how-to-download-and-deploy-mdop-group-policy--admx--templates.md).
 
 ### Purchase MDOP


### PR DESCRIPTION
Microsoft Desktop Optimization Pack can also be downloaded with certain Visual Studio subscriptions, so I've added a line about that.

There might be a better way to word it than I did, so feel free to change it around. I just figured it should mention it somehow. 

For example, it seems like mostly just Visual Studio Enterprise subscriptions have access but there are a few exceptions, so I just said "certain" subscriptions.

Here it is in the downloads section in the subscription portal:

![image](https://github.com/MicrosoftDocs/mdop-docs/assets/12518330/4f52055f-38ed-4c4e-b626-8921aa9dd09c)
